### PR TITLE
get make deploy to install stably by moving sa etc out of reconcile loop

### DIFF
--- a/build/assets/master/0400_master_deployment.yaml
+++ b/build/assets/master/0400_master_deployment.yaml
@@ -66,20 +66,16 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts: []
           livenessProbe:
-            exec:
-              command:
-              - /usr/bin/grpc_health_probe
-              - -addr=:12000
+            grpc:
+              port: 8082
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
-            exec:
-              command:
-              - /usr/bin/grpc_health_probe
-              - -addr=:12000
+            grpc:
+              port: 8082
             failureThreshold: 10
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/config/crd/bases/nfd.k8s-sigs.io_nodefeatures.yaml
+++ b/config/crd/bases/nfd.k8s-sigs.io_nodefeatures.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: nodefeatures.nfd.k8s-sigs.io
+spec:
+  group: nfd.k8s-sigs.io
+  names:
+    kind: NodeFeature
+    listKind: NodeFeatureList
+    plural: nodefeatures
+    singular: nodefeature
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeFeature resource holds the features discovered for one node
+          in the cluster.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeFeatureSpec describes a NodeFeature object.
+            properties:
+              features:
+                description: Features is the full "raw" features data that has been
+                  discovered.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      description: AttributeFeatureSet is a set of features having
+                        string value.
+                      properties:
+                        elements:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                      - elements
+                      type: object
+                    description: Attributes contains all the attribute-type features
+                      of the node.
+                    type: object
+                  flags:
+                    additionalProperties:
+                      description: FlagFeatureSet is a set of simple features only
+                        containing names without values.
+                      properties:
+                        elements:
+                          additionalProperties:
+                            description: Nil is a dummy empty struct for protobuf
+                              compatibility
+                            type: object
+                          type: object
+                      required:
+                      - elements
+                      type: object
+                    description: Flags contains all the flag-type features of the
+                      node.
+                    type: object
+                  instances:
+                    additionalProperties:
+                      description: InstanceFeatureSet is a set of features each of
+                        which is an instance having multiple attributes.
+                      properties:
+                        elements:
+                          items:
+                            description: InstanceFeature represents one instance of
+                              a complex features, e.g. a device.
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            required:
+                            - attributes
+                            type: object
+                          type: array
+                      required:
+                      - elements
+                      type: object
+                    description: Instances contains all the instance-type features
+                      of the node.
+                    type: object
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels is the set of node labels that are requested to
+                  be created.
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/config/crd/bases/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yaml
+++ b/config/crd/bases/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
-  name: nodefeaturerules.nfd.kubernetes.io
+  name: nodefeaturerules.nfd.k8s-sigs.io
 spec:
-  group: nfd.kubernetes.io
+  group: nfd.k8s-sigs.io
   names:
     kind: NodeFeatureRule
     listKind: NodeFeatureRuleList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,8 +3,9 @@
 # It should be run by config/default
 resources:
 - bases/nfd.kubernetes.io_nodefeaturediscoveries.yaml
-- bases/nfd.kubernetes.io_v1alpha1_nodefeaturerules.yaml
+- bases/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yaml
 - bases/node.k8s.io_v1alpha1_noderesourcetopologies.yaml
+- bases/nfd.k8s-sigs.io_nodefeatures.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 commonAnnotations:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,3 +24,8 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../worker
+- ../master
+- ../gc
+- ../prune
+- ../topologyupdater

--- a/config/gc/clusterrole.yaml
+++ b/config/gc/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: nfd-gc
+  name: gc
 rules:
 - apiGroups:
   - ""

--- a/config/gc/clusterrolebinding.yaml
+++ b/config/gc/clusterrolebinding.yaml
@@ -1,13 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: nfd-master
+  name: gc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: nfd-master
+  name: gc
 subjects:
 - kind: ServiceAccount
-  name: nfd-master
-  namespace: node-feature-discovery-operator
-
+  name: nfd-gc
+  namespace: default 

--- a/config/gc/kustomization.yaml
+++ b/config/gc/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- clusterrole.yaml
+- clusterrolebinding.yaml
+- serviceaccount.yaml

--- a/config/gc/serviceaccount.yaml
+++ b/config/gc/serviceaccount.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nfd-worker
-
+  name: gc

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: gcr.io/k8s-staging-nfd/node-feature-discovery-operator
-  newTag: master
+  newName: registry.k8s.io/nfd/node-feature-discovery-operator
+  newTag: 0.4.2

--- a/config/manifests/bases/nfd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd-operator.clusterserviceversion.yaml
@@ -97,7 +97,7 @@ spec:
     - description: |
         NodeFeatureRule resource specifies a configuration for feature-based customization of node objects, such as node labeling.
       kind: NodeFeatureRule
-      name: nodefeaturerules.nfd.kubernetes.io
+      name: nodefeaturerules.nfd.k8s-sigs.io
       version: v1alpha1
     - description: |
         NodeResourceTopology resource describes node resources and their topology.

--- a/config/master/clusterrole.yaml
+++ b/config/master/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: nfd-master
+  name: master
 rules:
 - apiGroups:
   - ""
@@ -13,6 +13,7 @@ rules:
   - get
   - patch
   - update
+  - list
 - apiGroups:
   - topology.node.k8s.io
   resources:
@@ -28,4 +29,12 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  verbs:
+  - list
+  - update
   - watch

--- a/config/master/clusterrole_binding.yaml
+++ b/config/master/clusterrole_binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: nfd-prune
+  name: master
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: nfd-prune
+  name: master
 subjects:
 - kind: ServiceAccount
-  name: nfd-prune
+  name: nfd-master
   namespace: node-feature-discovery-operator
 

--- a/config/master/kustomization.yaml
+++ b/config/master/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- service_account.yaml
+- clusterrole.yaml
+- clusterrole_binding.yaml

--- a/config/master/service_account.yaml
+++ b/config/master/service_account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nfd-gc
+  name: master

--- a/config/prune/clusterole_binding.yaml
+++ b/config/prune/clusterole_binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: nfd-worker
+  name: prune
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: nfd-worker
+  kind: ClusterRole
+  name: prune
 subjects:
 - kind: ServiceAccount
-  name: nfd-worker
+  name: nfd-prune
   namespace: node-feature-discovery-operator
 

--- a/config/prune/clusterrole.yaml
+++ b/config/prune/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: nfd-topology-updater
+  name: prune
 rules:
 - apiGroups:
   - ""
@@ -9,10 +9,6 @@ rules:
   - nodes
   verbs:
   - get
+  - patch
+  - update
   - list
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get

--- a/config/prune/kustomization.yaml
+++ b/config/prune/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- service_account.yaml
+- clusterrole.yaml
+- clusterole_binding.yaml

--- a/config/prune/service_account.yaml
+++ b/config/prune/service_account.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nfd-master
-
+  name: prune

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,6 +1,6 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - nfd.kubernetes.io_v1_nodefeaturediscovery.yaml
-- nfd.kubernetes.io_v1alpha1_nodefeaturerules.yaml
+- nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples
 

--- a/config/samples/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yam
+++ b/config/samples/nfd.k8s-sigs.io_v1alpha1_nodefeaturerules.yam
@@ -1,4 +1,4 @@
-apiVersion: nfd.kubernetes.io/v1alpha1
+apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:
   name: my-sample-rule-object

--- a/config/topologyupdater/clusterrole.yaml
+++ b/config/topologyupdater/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: nfd-prune
+  name: topology-updater
 rules:
 - apiGroups:
   - ""
@@ -9,6 +9,10 @@ rules:
   - nodes
   verbs:
   - get
-  - patch
-  - update
   - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get

--- a/config/topologyupdater/clusterrolebinding.yaml
+++ b/config/topologyupdater/clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: nfd-topology-updater
+  name: topology-updater
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: nfd-topology-updater
+  name: topology-updater
 subjects:
 - kind: ServiceAccount
   name: nfd-topology-updater

--- a/config/topologyupdater/kustomization.yaml
+++ b/config/topologyupdater/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- service_account.yaml
+- clusterrole.yaml
+- clusterrolebinding.yaml

--- a/config/topologyupdater/service_account.yaml
+++ b/config/topologyupdater/service_account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nfd-topology-updater
+  name: topology-updater

--- a/config/worker/kustomization.yaml
+++ b/config/worker/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- service_account.yaml
+- role.yaml
+- rolebinding.yaml
+

--- a/config/worker/role.yaml
+++ b/config/worker/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: nfd-worker
+  name: worker
 rules:
 - apiGroups:
   - policy
@@ -11,4 +11,11 @@ rules:
   - use
   resourceNames:
   - nfd-worker
-
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  verbs:
+  - get
+  - create
+  - update

--- a/config/worker/rolebinding.yaml
+++ b/config/worker/rolebinding.yaml
@@ -1,12 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: nfd-gc
+  name: worker
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: nfd-gc
+  kind: Role
+  name: worker
 subjects:
 - kind: ServiceAccount
-  name: nfd-gc
-  namespace: default 
+  name: nfd-worker
+  namespace: node-feature-discovery-operator
+

--- a/config/worker/service_account.yaml
+++ b/config/worker/service_account.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nfd-prune
+  name: worker
+

--- a/controllers/nodefeaturediscovery_controls.go
+++ b/controllers/nodefeaturediscovery_controls.go
@@ -451,18 +451,6 @@ func Deployment(n NFD) (ResourceStatus, error) {
 	}
 
 	var args []string
-	port := defaultServicePort
-
-	// If the operand service port has already been defined,
-	// then set "port" to the defined port. Otherwise, it is
-	// ok to just use the defaultServicePort value
-	if n.ins.Spec.Operand.ServicePort != 0 {
-		port = n.ins.Spec.Operand.ServicePort
-	}
-
-	// Now that the port has been determined, append it to
-	// the list of args
-	args = append(args, fmt.Sprintf("--port=%d", port))
 
 	// Check if running as instance. If not, then it is
 	// expected that n.ins.Spec.Instance will return ""


### PR DESCRIPTION
At the moment make deploy fails, with pods crashing due to missing CRDs, missing permissions, incorrect liveness probes etc  this PR fixes these issues and allows `make deploy` to deploy NFD correctly and in a working state.

As part of this I have moved the serviceaccount, clusterrole, role, and rolebinding deployment from the reconcile loop (the  build/assests/* directories )  to being created at deploy time by kustomize (from the config/* directory). This is following #210 and because the operator can only create roles with permissions it holds itself so the reconciler needs
a whole range of additional permissions   for the deploy-at-reconcile model to work.